### PR TITLE
Add Jenkinsfile and single bash script to update & publish changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,24 @@
+#!groovy
+
+// define global vars for use in later stages
+def gitCommitId = null
+
+stage('Checkout') {
+  node {
+    deleteDir()
+
+    checkout scm
+
+    gitCommitId = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+
+    currentBuild.displayName = "#${env.BUILD_NUMBER}:${env.VERSION}"
+  }
+}
+
+stage ('Generate and publish OpenAPI specs') {
+  node {
+    timeout(time: 10, unit: 'MINUTES') {
+      sh "./ci/publish.bash ${env.VERSION} ${env.BUILD_URL}"
+    }
+  }
+}

--- a/ci/publish.bash
+++ b/ci/publish.bash
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+set -Euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: ${0} <VERSION> <BUILD_URL>"
+  echo "Please specify a VERSION of the Instana backend and the corresponding openapi-deploy BUILD_URL"
+  echo "Example: ${0} \"1.181.548\" \"https://dev-jenkins.instana.io/job/openapi-deploy/77/\""
+  exit 1
+fi
+
+if ! command -v mvn >/dev/null ; then
+  echo "Required command not found: mvn"
+  exit 1
+fi
+
+if ! command -v git >/dev/null ; then
+  echo "Required command not found: git"
+  exit 1
+fi
+
+VERSION="${1}"
+BUILD_URL="${2}"
+SCRIPT_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+
+echo "Downloading new OpenAPI spec..."
+mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get \
+    -Dartifact=com.instana:openapi:${VERSION}:yaml \
+    -Ddest=${SCRIPT_ROOT_DIR}/spec/openapi.yaml
+
+# Replace version placeholder
+sed -i -e "s/INSTANA_BACKEND_BUILD_VERSION/${VERSION}/g" ${SCRIPT_ROOT_DIR}/spec/openapi.yaml
+
+echo "Installing dependencies..."
+source $HOME/.nvm/nvm.sh
+nvm use
+npm install
+
+if [ -z "$(which yarn)" ]; then
+  npm install -g yarn@1.9.4
+fi
+
+echo "Generating spec descriptions..."
+yarn build
+
+echo "Commit and push changes"
+git checkout master
+git add .
+git commit -q -a -m "Added generated spec files, see ${BUILD_URL}"
+git push -q origin master
+
+echo "Publish changes to gh-pages"
+yarn gh-pages


### PR DESCRIPTION
## Why

The current code that generates and updates the OpenAPI specs on github-pages is hardcoded on the Jenkins job `openapi-deploy`: https://dev-jenkins.instana.io/job/openapi-deploy/.

This introduces risk in case dev-jenkins somehow disappears completely and we're unable to restore it, this logic will be lost and we would have to rewrite it. Also if we wanted to move to a different CI server, pulling this logic out of dev-jenkins will make the transition easier and less confusing.

## What

Encode the steps to update and publish changes to the OpenAPI specs in a bash script and add a Jenkinsfile to hardcode as little as possible on the actual CI server. This will also allow us to add additional steps after the publishing to trigger things like running the API end-to-end tests.

`publish.bash` contains the same code that lives in the shell script here: https://dev-jenkins.instana.io/job/openapi-deploy/configure
