### PR TITLE
Add additional Jenkins stage to trigger API end-to-end tests after the new OpenAPI spec has been published

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,3 +22,19 @@ stage ('Generate and publish OpenAPI specs') {
     }
   }
 }
+
+stage ('Trigger API end-to-end tests') {
+  timeout(time: 30, unit: 'MINUTES') {
+    if (env.BRANCH_NAME == 'master') {
+      withCredentials([string(credentialsId: 'internal-instanaops-instana-api-token', variable: 'INSTANA_API_TOKEN')]) {
+        build job: '/tests/rest-api-e2e-tests', parameters: [
+            string(name: 'BRANCH_NAME', value: 'develop'),
+            string(name: 'OPENAPI_URL', value: 'https://instana.github.io/openapi/openapi.yaml'),
+            string(name: 'INSTANA_API_URL', value: 'https://internal-instanaops.instana.io/'),
+            string(name: 'INSTANA_API_TOKEN', value: "${INSTANA_API_TOKEN}"),
+            string(name: 'OPSGENIE_BASE_PATH', value: 'https://api.eu.opsgenie.com')
+        ]
+      }
+    }
+  }
+}

--- a/ci/publish.bash
+++ b/ci/publish.bash
@@ -22,6 +22,7 @@ fi
 
 VERSION="${1}"
 BUILD_URL="${2}"
+BRANCH_NAME=${BRANCH_NAME:='master'}
 SCRIPT_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
 
 echo "Downloading new OpenAPI spec..."
@@ -44,11 +45,11 @@ fi
 echo "Generating spec descriptions..."
 yarn build
 
-echo "Commit and push changes"
-git checkout master
+echo "Commit and push changes to ${BRANCH_NAME}"
+git checkout $BRANCH_NAME
 git add .
 git commit -q -a -m "Added generated spec files, see ${BUILD_URL}"
-git push -q origin master
+git push -q origin $BRANCH_NAME
 
 echo "Publish changes to gh-pages"
 yarn gh-pages


### PR DESCRIPTION
## Why

Once we've published a new version of the OpenAPI spec to https://instana.github.io/openapi/, we should also run the existing API end-to-end tests with that spec on an API url belonging to a production Instana tenant unit.

## What

We're triggering the [API end-to-end tests](https://dev-jenkins.instana.io/job/tests/job/rest-api-e2e-tests/) using the public OpenAPI spec on https://instana.github.io/openapi/openapi.yaml on the API url for a production Instana tenant unit [internal-instanaops](https://internal-instanaops.instana.io/).