### PR TITLE
Add custom dashboard API section introduction

### DIFF
--- a/spec/descriptions/tagCustomDashboards.md
+++ b/spec/descriptions/tagCustomDashboards.md
@@ -1,0 +1,4 @@
+You can use these API endpoints to manage custom dashboards. We recommend
+that you leverage the `Edit as JSON` feature found within our user interface
+to construct the desired request payloads. Specifically to help you build
+correct widget configurations and access rules.


### PR DESCRIPTION
# Why

The custom dashboard request payload is highly complicated. Customers
are unlikely to figure out the correct request payload based on
OpenAPI specs.

# What

Suggest to use `Edit as JSON` in the UI to have a simple way to copy
a valid custom dashboard configuration.