### PR TITLE
Add applicationAlertConfig docs

### DIFF
--- a/spec/descriptions/tagApplicationAlertConfiguration.md
+++ b/spec/descriptions/tagApplicationAlertConfiguration.md
@@ -1,0 +1,3 @@
+The endpoints of this group can be used to manage Application alert configurations. These endpoints are only available for customers who have opted-in for the BETA feature "Application Smart Alerts".
+In order to use this feature or to have more information, please contact <support@instana.com>.
+


### PR DESCRIPTION
Indicate that the endpoint is a beta feature and only the customers who have enabled this beta feature can use this endpoint.

