### PR TITLE
release-204: Expose includeInternal and includeSynthetic flags in call-groups resource

### DIFF
--- a/spec/descriptions/getCallGroup.md
+++ b/spec/descriptions/getCallGroup.md
@@ -1,4 +1,4 @@
 This endpoint retrieves the metrics for calls.
 
 ## Deprecated Parameters
-**tagFilters:** The list of tag filters. It is replaced by **tagFilterExpression**
+**tagFilters:** The list of tag filters. It is replaced by **tagFilterExpression**, **includeInternal** and **includeSynthetic**.


### PR DESCRIPTION
## What

Expose includeInternal and includeSynthetic flags in call-groups resource.

## References
-  https://instana.kanbanize.com/ctrl_board/66/cards/62225/details/