### PR TITLE
[release-210] Deprecate tag filters in Get Beacon Groups

### DIFF
--- a/spec/descriptions/getBeaconGroups.md
+++ b/spec/descriptions/getBeaconGroups.md
@@ -1,11 +1,4 @@
-This endpoint retrieves the metrics for infrastructure components.
+This endpoint retrieves groups of beacons and aggregated metrics.
 
-**Manditory Paramters:**
-
-**Optional Paramters:**
-
-**Defaults:**
-
-**Limits:**
-
-**Tips:**
+## Deprecated Parameters
+**tagFilters:** it is replaced by **tagFilterExpression**

--- a/spec/descriptions/tagWebsiteAnalyze.md
+++ b/spec/descriptions/tagWebsiteAnalyze.md
@@ -6,7 +6,7 @@ The following four endpoints expose our analyze functionality.
 
 **group (only for group Endpoints)** It is mandatory to select a tag by which the beacons are grouped for the distinct endpoint call
 * *groupByTag* select a tag by which the beacons are grouped 
-  * a full list of available tags can be retrieved from [tags catalogue](#operation/getTagsForWeb)
+  * a full list of available tags can be retrieved from [tags catalogue](#operation/getWebsiteCatalogTags)
 * *groupByTagSecondLevelKey* tags of type KEY_VALUE_PAIR need a second parameter e.g for `beacon.meta` you would need provide the label you want to groupBy here.
 
 
@@ -26,7 +26,7 @@ The following four endpoints expose our analyze functionality.
 <----------------------|
 ```
 
-**tagFilters** As in the UI you able to filter your query by a tag. To get a list of all available tags you can query the [tag catalog](#operation/getTagsForApplication)
+**tagFilterExpression** As in the UI you are able to filter your query using tags and operators such as `AND` and `OR`. To get a list of all available tags you can query the [tag catalog](#operation/getWebsiteCatalogTags)
 * *name* The name of the tag as returned by the catalog, e.g `beacon.meta`, `beacon.http.path`
 * *value* The filter value of the tag, possible types are:
   * "STRING" alphanumerical values, valid operators: "EQUALS", "CONTAINS", "NOT_EQUAL", "NOT_CONTAIN", "NOT_EMPTY",  "IS_EMPTY"
@@ -38,7 +38,7 @@ The following four endpoints expose our analyze functionality.
 1. *metric* select a particular metric, available metrics in this context are
    * Latency Mean
    * Error Rate
-2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalogue endpoint](#operation/getMetricDefinitions) gives you the metrics with the available aggregations.
+2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalogue endpoint](#operation/getWebsiteCatalogMetrics) gives you the metrics with the available aggregations.
 3. *granularity* 
    * if it is not set you will get a an aggregated value for the selected timeframe. 
    * if the granularity is set you will get data points with the specified granularity in seconds


### PR DESCRIPTION
Deprecation done here: 
https://github.com/instana/backend/pull/12122

API docs updated similarly to https://github.com/instana/openapi/pull/18