### PR TITLE
Improve docs related to metric granularity

### DIFF
--- a/spec/descriptions/tagApplicationAnalyze.md
+++ b/spec/descriptions/tagApplicationAnalyze.md
@@ -39,9 +39,10 @@ Furthermore you can [search and filter all traces](#operation/getTraces) and ret
    * Traces Sum
 2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalogue endpoint](#operation/getApplicationCatalogMetrics) gives you the metrics with the available aggregations.
 3. *granularity* 
-   * if it is not set you will get a an aggregated value for the selected timeframe. 
-   * if the granularity is set you will get data points with the specified granularity in seconds
-   * The value can be selected freely between 1 - selected windowSize.
+   * If it is not set you will get a an aggregated value for the selected timeframe
+   * If the granularity is set you will get data points with the specified granularity **in seconds**
+    * The granularity should not be greater than the `windowSize` (important: `windowSize` is expressed in **milliseconds**)
+    * The granularity should not be set too small relative to the `windowSize` to avoid creating an excessively large number of data points (max 600)
 
 ### Defaults:
 **timeFrame**

--- a/spec/descriptions/tagApplicationMetrics.md
+++ b/spec/descriptions/tagApplicationMetrics.md
@@ -7,12 +7,13 @@ The endpoints of this group retrieve the metrics for defined applications, disco
 
 ### Optional Parameters
 
-**metrics** Default you will get an aggregated metric with for the selected timeFrame 
+**metrics** Default you will get an aggregated metric with for the selected timeframe 
 
 * *granularity* 
-  * if it is not set you will get a an aggregated value for the selected timeframe. 
-  * if the granularity is set you will get data points with the specified granularity in seconds
-    * The value can be selected freely between 1 - selected windowSize.
+   * If it is not set you will get a an aggregated value for the selected timeframe
+   * If the granularity is set you will get data points with the specified granularity **in seconds**
+    * The granularity should not be greater than the `windowSize` (important: `windowSize` is expressed in **milliseconds**)
+    * The granularity should not be set too small relative to the `windowSize` to avoid creating an excessively large number of data points (max 600)
    
 **pagination** if you use pagination you most probably want to fix the timeFrame for the retrieved metrics
 1. *page* select the page number you want to retrieve

--- a/spec/descriptions/tagWebsiteAnalyze.md
+++ b/spec/descriptions/tagWebsiteAnalyze.md
@@ -40,9 +40,10 @@ The following four endpoints expose our analyze functionality.
    * Error Rate
 2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalogue endpoint](#operation/getWebsiteCatalogMetrics) gives you the metrics with the available aggregations.
 3. *granularity* 
-   * if it is not set you will get a an aggregated value for the selected timeframe. 
-   * if the granularity is set you will get data points with the specified granularity in seconds
-   * The value can be selected freely between 1 - selected windowSize.
+   * If it is not set you will get a an aggregated value for the selected timeframe
+   * If the granularity is set you will get data points with the specified granularity **in seconds**
+    * The granularity should not be greater than the `windowSize` (important: `windowSize` is expressed in **milliseconds**)
+    * The granularity should not be set too small relative to the `windowSize` to avoid creating an excessively large number of data points (max 600)
  
 
 ## Defaults:


### PR DESCRIPTION
The following statement about the metric granularity is misleading:
> The value can be selected freely between 1 - selected windowSize.

This is not true because if the granularity is too small relative to the window size, it would generate a very large number of data points, and the request would fail with the following error message:
```
"'xxx' metric: the granularity in relation to the windowSize provides too many values"
```

We allow up to 600 data points. 

Update the docs accordingly for:
- AP metrics
- AP Analyze
- Website Analyze