### PR TITLE
Update dead links to AP tag catalog

### DIFF
--- a/spec/descriptions/info.md
+++ b/spec/descriptions/info.md
@@ -172,7 +172,7 @@ func readTags() {
 		Prefix: "apiToken",
 	})
 
-	tags, _, err := client.ApplicationCatalogApi.GetTagsForApplication(auth)
+	tags, _, err := client.ApplicationCatalogApi.GetApplicationTagCatalog(auth)
 	if err != nil {
 		fmt.Fatalf("Error calling the API, aborting.")
 	}

--- a/spec/descriptions/tagApplicationAnalyze.md
+++ b/spec/descriptions/tagApplicationAnalyze.md
@@ -6,7 +6,7 @@ Furthermore you can [search and filter all traces](#operation/getTraces) and ret
 ### Mandatory Parameters (only for group Endpoints):
 **group** It is mandatory to select a tag by which the calls and traces are grouped for the distinct endpoint call
 * *groupByTag* select a tag by which the calls and traces are grouped 
-  * a full list of available tags can be retrieved from [tags catalogue](#operation/getTagsForApplication)
+  * a full list of available tags can be retrieved from the [application tag catalog](#operation/getApplicationTagCatalog)
   * for the trace endpoint only two tags are reasonable and working: `trace.endpoint.name` and `trace.service.name` which indicate the entry endpoint or service for the trace
 * *groupByTagSecondLevelKey* tags of type KEY_VALUE_PAIR need a second parameter e.g for `kubernetes.deployment.label` you would need provide the label you want to groupBy here.
 
@@ -25,7 +25,7 @@ Furthermore you can [search and filter all traces](#operation/getTraces) and ret
 ```
 The timeFrame might be adjusted to fit the metric granularity so that there is no partial bucket. For example, if the query timeFrame is 08:02 - 09:02 and the metric granularity is 5 minutes, the timeFrame will be adjusted to 08:05 - 09:00. The adjusted timeFrame will be returned in the response payload. If the query does not have any metric with granularity, a default granularity will be used for adjustment.
 
-**tagFilters** As in the UI you able to filter your query by a tag. To get a list of all available tags you can query the [tag catalog](#operation/getApplicationCatalogTags)
+**tagFilters** As in the UI you able to filter your query by a tag. To get a list of all available tags you can query the [application tag catalog](#operation/getApplicationTagCatalog)
 * *name* The name of the tag as returned by the catalog
 * *value* The filter value of the tag, possible types are:
   * "STRING" alphanumerical values, valid operators: "EQUALS", "CONTAINS", "NOT_EQUAL", "NOT_CONTAIN", "NOT_EMPTY",  "IS_EMPTY"
@@ -38,7 +38,7 @@ The timeFrame might be adjusted to fit the metric granularity so that there is n
    * Latency Mean
    * Error Rate
    * Traces Sum
-2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalogue endpoint](#operation/getApplicationCatalogMetrics) gives you the metrics with the available aggregations.
+2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalog endpoint](#operation/getApplicationCatalogMetrics) gives you the metrics with the available aggregations.
 3. *granularity* 
    * If it is not set you will get a an aggregated value for the selected timeframe
    * If the granularity is set you will get data points with the specified granularity **in seconds**

--- a/spec/descriptions/tagApplicationMetrics.md
+++ b/spec/descriptions/tagApplicationMetrics.md
@@ -2,8 +2,8 @@ The endpoints of this group retrieve the metrics for defined applications, disco
 ### Mandatory Parameters
 
 **metrics** A list of metric objects that define which metric should be returned, with the defined aggregation. Each metrics objects consists of minimum two items:
-1. *metric* select a particular metric to get a list of available metrics query the [catalogue endpoint](#operation/getMetricDefinitions)
-2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalogue endpoint](#operation/getMetricDefinitions) gives you the metrics with the available aggregations.
+1. *metric* select a particular metric to get a list of available metrics query the [catalog endpoint](#operation/getApplicationCatalogMetrics)
+2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalog endpoint](#operation/getApplicationCatalogMetrics) gives you the metrics with the available aggregations.
 
 ### Optional Parameters
 

--- a/spec/descriptions/tagWebsiteAnalyze.md
+++ b/spec/descriptions/tagWebsiteAnalyze.md
@@ -6,7 +6,7 @@ The following four endpoints expose our analyze functionality.
 
 **group (only for group Endpoints)** It is mandatory to select a tag by which the beacons are grouped for the distinct endpoint call
 * *groupByTag* select a tag by which the beacons are grouped 
-  * a full list of available tags can be retrieved from [tags catalogue](#operation/getWebsiteCatalogTags)
+  * a full list of available tags can be retrieved from the [website tag catalog](#operation/getWebsiteCatalogTags)
 * *groupByTagSecondLevelKey* tags of type KEY_VALUE_PAIR need a second parameter e.g for `beacon.meta` you would need provide the label you want to groupBy here.
 
 
@@ -38,7 +38,7 @@ The following four endpoints expose our analyze functionality.
 1. *metric* select a particular metric, available metrics in this context are
    * Latency Mean
    * Error Rate
-2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalogue endpoint](#operation/getWebsiteCatalogMetrics) gives you the metrics with the available aggregations.
+2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalog endpoint](#operation/getWebsiteCatalogMetrics) gives you the metrics with the available aggregations.
 3. *granularity* 
    * If it is not set you will get a an aggregated value for the selected timeframe
    * If the granularity is set you will get data points with the specified granularity **in seconds**


### PR DESCRIPTION
A few links are outdated / dead and should point to the latest AP tag catalog.
Furthermore, the code example was referencing this example, however the API was changed at least 2 times in the meantime, and therefore also that particular example was outdated.