### PR TITLE
[R224] Add docs for PUT and DELETE of custom-event-spec

### DIFF
--- a/spec/descriptions/deleteCustomEventSpecification.md
+++ b/spec/descriptions/deleteCustomEventSpecification.md
@@ -1,0 +1,18 @@
+This endpoint deletes a Custom Event Specification.
+
+By default, the ID of a deleted configuration cannot be reused anymore to enable links in previous Issues or Incidents to stay valid.
+However, check out the docs for [updating a configuration](#operation/putCustomEventSpecification) how this default behavior can be changed using the `allowRestore` query parameter.
+
+
+## Mandatory Parameters:
+
+- **eventSpecificationId (Path Parameter):** A unique identifier for the custom event specification to delete.
+
+
+# Example:
+
+```
+curl --request DELETE 'https://<Host>/api/events/settings/event-specifications/custom/<EventSpecificationId>' \
+--header 'Authorization: apiToken <Token>' \
+--header 'Content-Type: application/json'
+```

--- a/spec/descriptions/postCustomEventSpecification.md
+++ b/spec/descriptions/postCustomEventSpecification.md
@@ -1,8 +1,6 @@
-This endpoint creates or updates a Custom Event Specification.
+This endpoint creates a new Custom Event Specification.
 
 ## Mandatory Parameters:
-
-- **eventSpecificationId (Path Parameter):** A unique identifier for each custom event
 
 - **name:** Name for the custom event
 
@@ -23,7 +21,7 @@ Depending on the chosen `ruleType`, there are further required parameters:
 - **rules.metricPattern.operator:** Operator for matching the metric
 
 ```
-curl --request PUT 'https://<Host>/api/events/settings/event-specifications/custom/<EventSpecificationId>' \
+curl --request POST 'https://<Host>/api/events/settings/event-specifications/custom' \
 --header 'Authorization: apiToken <Token>' \
 --header 'Content-Type: application/json' \
 --data-raw '{ "description":"Event for OpenAPI documentation", "enabled":true,"entityType":"host","expirationTime":"60000","name":"Event for OpenAPI documentation",
@@ -41,7 +39,7 @@ The above example creates a custom event that matches disk devices that end with
 - **rules.metricName:** Metric name for the event
 
 ```
-curl --request PUT 'https://<Host>/api/events/settings/event-specifications/custom/<EventSpecificationId>' \
+curl --request POST 'https://<Host>/api/events/settings/event-specifications/custom' \
 --header 'Authorization: apiToken <Token>' \
 --header 'Content-Type: application/json' \
 --data-raw '{ "description":"Event for OpenAPI documentation fixed Metric", "enabled":true,"entityType":"host","expirationTime":"60000",
@@ -55,7 +53,7 @@ curl --request PUT 'https://<Host>/api/events/settings/event-specifications/cust
 - **rules.systemRuleId:** Id of the System Rule being set 
 
 ```
-curl --request PUT 'https://<Host>/api/events/settings/event-specifications/custom/<EventSpecificationId>' \
+curl --request POST 'https://<Host>/api/events/settings/event-specifications/custom' \
 --header 'Authorization: apiToken <Token>' \
 --header 'Content-Type: application/json' \
 --data-raw '{ "description":"Event for OpenAPI documentation System Rule", "enabled":true,"entityType":"any","expirationTime":"60000",
@@ -70,7 +68,7 @@ curl --request PUT 'https://<Host>/api/events/settings/event-specifications/cust
 - **rules.matchingEntityLabel:** Name Pattern for the Entity
 
 ```
-curl --request PUT 'https://<Host>/api/events/settings/event-specifications/custom/<EventSpecificationId>' \
+curl --request POST 'https://<Host>/api/events/settings/event-specifications/custom' \
 --header 'Authorization: apiToken <Token>' \
 --header 'Content-Type: application/json' \
 --data-raw '{ "description":"Event for OpenAPI Entity Verification Rule", "enabled":true,"entityType":"host","expirationTime":"60000",
@@ -79,7 +77,3 @@ curl --request PUT 'https://<Host>/api/events/settings/event-specifications/cust
 "ruleType":"entity_verification","severity": 5}], "triggering":false
 }'
 ```
-
-## Optional Parameters:
-
-- **allowRestore (Query Parameter):** Allows to restore a custom event specification that was previously deleted or migrated when set to `true`. This allows to have idempotent operations that can be useful in _configuration as code_ scenarios. By default, the ID of a deleted configuration cannot be reused anymore to enable links in previous Issues or Incidents to stay valid. 


### PR DESCRIPTION
# What / Why?

We are adding a new `POST` endpoint, as well as a `allowRestore` query param to `PUT` as part of R224.
Furthermore, the (redundant) ID in the payload is no more needed. Last but not least, we are making the default behavior of `DELETE` explicit, and refer to `allowRestore` in case users have different use-cases (e.g. for alerting-as-code).

# References

- [Card](https://instana.kanbanize.com/ctrl_board/37/cards/94254/details/)
- https://github.ibm.com/instana/backend/pull/14820/files