### PR TITLE
Improve getEvents docs example

### DIFF
--- a/spec/descriptions/getEvents.md
+++ b/spec/descriptions/getEvents.md
@@ -9,11 +9,18 @@ This endpoint retrieves all available events for the requested timeframe.
 This option is more restrictive than `filterEventUpdates` and does not inform about event state updates that got `CLOSED` in the timeframe of the query if not also the start time of the event is within that query timeframe.
 - **filterEventUpdates:** Filters results to event updates only. This means that an event is only included when its event state changed in the given query timeframe. This is useful for 3rd party integrations that fetch events from Instana with a scheduled batch job in a fixed interval using a tumbling windows, when you care about event state updates.
 
-### Example
+### Examples
 
-Fetch all events that have been opened or closed within the last 30 minutes.
+Fetch all events that have been opened within the last 30 seconds.
 
 ```bash
-curl --request GET 'https://<HOST>/api/events?windowSize=30000&filterEventUpdates=true' \
+curl --request GET 'https://<Host>/api/events?windowSize=30000&excludeTriggeredBefore=true' \
+--header 'Authorization: apiToken <Token>'
+```
+
+Fetch all events that have been opened or closed within the last minute, using a fetch delay of 120 seconds.
+
+```bash
+TO_MILLIS=$((($(date +%s) - 120) * 1000)) curl --request GET "https://<Host>/api/events?windowSize=60000&to=$TO_MILLIS&filterEventUpdates=true" \
 --header 'Authorization: apiToken <Token>'
 ```

--- a/spec/descriptions/getEvents.md
+++ b/spec/descriptions/getEvents.md
@@ -11,10 +11,10 @@ This option is more restrictive than `filterEventUpdates` and does not inform ab
 
 ### Examples
 
-Fetch all events that have been opened within the last 30 seconds.
+Fetch all events that have been opened within the last 30 minutes.
 
 ```bash
-curl --request GET 'https://<Host>/api/events?windowSize=30000&excludeTriggeredBefore=true' \
+curl --request GET 'https://<Host>/api/events?windowSize=1800000&excludeTriggeredBefore=true' \
 --header 'Authorization: apiToken <Token>'
 ```
 


### PR DESCRIPTION
# Why?

Improve the docs of the example stated in `getEvents`, which was currently actually suggesting something that is not really recommended: When using `filterEventUpdates`, as stated in the description of `to` above, it is recommended to fetch data with a delay.

This [ZD-ticket](https://instana.zendesk.com/agent/tickets/25880) has shown that customers not rarely start with the given example "copy-paste". So the examples we are stating here should reflect more what we actually recommend.

# Links

- https://instana.zendesk.com/agent/tickets/25880