### PR TITLE
Add details to group api

### DIFF
--- a/spec/descriptions/addUsersToGroup.md
+++ b/spec/descriptions/addUsersToGroup.md
@@ -1,0 +1,1 @@
+Add one or more users to a group. The array contains the ids of the users to be added.

--- a/spec/descriptions/createGroup.md
+++ b/spec/descriptions/createGroup.md
@@ -1,0 +1,20 @@
+Creates a group on the tenant unit. Each group entry also needs a `Permission Set`.
+
+The `Permission Set` object contains a set of permissions applied to the group.
+
+In case `permissions` include the entry `RESTRICTED_ACCESS`, this group will have a scope limited by its areas.
+
+When `permissions` contains `RESTRICTED_ACCESS`, permissions with preffix `ACCESS_*`are applied.
+
+Possible access permissions values are:
+
+- ACCESS_APPLICATIONS
+- ACCESS_KUBERNETES
+- ACCESS_MOBILE_APPS
+- ACCESS_WEBSITES
+
+The `id` value for the group is ignored, a new id is generated.
+
+The `scopeRoleId` is ignored, the id corresponding to the area is used.
+
+The `scopeId` is the id for the corresponding resource.

--- a/spec/descriptions/createGroupMapping.md
+++ b/spec/descriptions/createGroupMapping.md
@@ -1,0 +1,7 @@
+Creates a mapping between a group from the IdP (LDAP, OIDC, SAML) and an Instana group.
+
+If the IdP is configured and mappings are enabled, every time a user logs in the `key` `value` pairs for this user sent by the idp will be evaluated.
+
+If they match the mapping, the user will be assigned to the group corresponding to the `groupId`.
+
+The value for id is ignored, a new value is generated.

--- a/spec/descriptions/getGroup.md
+++ b/spec/descriptions/getGroup.md
@@ -1,0 +1,1 @@
+Returns group data, including the `Permission set`. See [get groups](#operation/getGroups) for more details.

--- a/spec/descriptions/getGroupMappings.md
+++ b/spec/descriptions/getGroupMappings.md
@@ -1,0 +1,3 @@
+If mappings between groups on the identity provider (LDAP, OIDC, SAML) and Instana groups where configured, this will return a list of those mappings.
+
+This can be configured through the [api](#operation/createGroupMapping) or inside Instana at Settings>IDENTITY PROVIDERS>Group Mapping

--- a/spec/descriptions/getGroups.md
+++ b/spec/descriptions/getGroups.md
@@ -1,0 +1,78 @@
+Retrieve the list of all groups on the tenant unit. Each group entry also includes a `Permission Set`.
+
+The `Permission Set` object contains a set of permissions applied to the group.
+
+In case `permissions` include the entry `RESTRICTED_ACCESS`, this group will have a scope limited by its areas.
+
+The areas are included inside the `permissionSet`.
+
+When `permissions` contains `RESTRICTED_ACCESS`, permissions with preffix `ACCESS_*`are applied.
+
+The scopeRoleId is a fixed value for each area type:
+
+| Area                    | value         |
+| ----------------------- | ------------- |
+| applicationIds          | -100          |
+| kubernetesClusterUUIDs  | -200          |
+| kubernetesNamespaceUIDs | -300          |
+| websiteIds              | -400          |
+| mobileAppIds            | -500          |
+| infraDfqFilter          | -600          |
+
+For example:
+
+```
+[
+    {
+        "id": "7hwdhtt7TU2CJDgYXgwwww",
+        "name": "Scoped Group",
+        "members": [
+            {
+                "userId": "61892cfdfcffab03016b2950",
+                "email": "jhon@example.com"
+            }
+        ],
+        "permissionSet": {
+        "permissions": [
+            "CAN_VIEW_LOGS",
+            "ACCESS_APPLICATIONS",
+            "ACCESS_KUBERNETES",
+            "CAN_VIEW_TRACE_DETAILS",
+            "ACCESS_MOBILE_APPS",
+            "RESTRICTED_ACCESS",
+            "CAN_EDIT_ALL_ACCESSIBLE_CUSTOM_DASHBOARDS"
+        ],
+        "applicationIds": [
+            {
+            "scopeId": "1qvWgVfLTNqi9gGTcCaNUw",
+            "scopeRoleId": "-100"
+            }
+        ],
+        "kubernetesClusterUUIDs": [
+            {
+            "scopeId": "induced",
+            "scopeRoleId": "-200"
+            }
+        ],
+        "kubernetesNamespaceUIDs": [],
+        "websiteIds": [
+        ],
+        "mobileAppIds": [
+            {
+            "scopeId": "GYSddOsgTZGtLx7wI8FZcQ",
+            "scopeRoleId": "-500"
+            }
+        ],
+        "infraDfqFilter": {
+            "scopeId": "production",
+            "scopeRoleId": "-600"
+        }
+    }
+]
+```
+In this case `Scoped Group` has no access to websites due to having `RESTRICTED_ACCESS` but not `ACCESS_WEBSITES`.
+
+Also due to having `RESTRICTED_ACCESS`, the only visible application is the one with this id: `1qvWgVfLTNqi9gGTcCaNUw`.
+
+Same applies to `kubernetesClusterUUIDs`, `kubernetesNamespaceUIDs`, `mobileAppIds`and `infraDfqFilter`, with the only difference is that `infraDfqFilter`
+uses a filter "production" instead of an id. 

--- a/spec/descriptions/getGroupsByUser.md
+++ b/spec/descriptions/getGroupsByUser.md
@@ -1,0 +1,1 @@
+Returns a list of all groups a user belongs to. This includes data from these groups, the `members`, the `name` and the `Permission set`.

--- a/spec/descriptions/updateGroup.md
+++ b/spec/descriptions/updateGroup.md
@@ -1,0 +1,7 @@
+Add a permission to a group. Permissions are strings associated with the group that some resources requires to fulfill requests.
+
+Some examples of `Permissions`:
+
+- `CAN_VIEW_AUDIT_LOG`
+- `ACCESS_WEBSITES` (only enforced when permissions also contains `RESTRICTED_ACCESS`)
+- More...

--- a/spec/descriptions/updateGroupMapping.md
+++ b/spec/descriptions/updateGroupMapping.md
@@ -1,0 +1,1 @@
+See [creating group mapping](#operation/createGroupMapping)


### PR DESCRIPTION
# Why

Missing documentation for the group API, specially for the `RESTRICTED_ACCESS` has caused confusion on how permissions should work.

This together with changes on the documentation tries to remediate that.

# What

Clarify `RESTRICTED_ACCESS` , permission sets and permissions