### PR TITLE
(Once again) un-beta the AP Smart Alerts API docs

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -12681,6 +12681,8 @@ x-tagGroups:
   - Application Analyze
   - Application Settings
   - Application Topology
+  - Application Alert Configuration
+  - Global Application Alert Configuration
 - name: Website Monitoring
   tags:
   - Website Metrics
@@ -12717,10 +12719,8 @@ x-tagGroups:
   tags:
   - SLI Settings
   - SLI Report
-- name: BETA Features
-  tags:
-  - Application Alert Configuration
-  - Global Application Alert Configuration
+# - name: BETA Features
+#   tags:
 - name: Technology Preview Features
   tags:
   - Synthetic Settings


### PR DESCRIPTION
the previous change https://github.com/instana/openapi/commit/c5712f89706f3c1df20996369372b436546e1da5 to un-beta it got reverted somehow in the previous commit https://github.com/instana/openapi/commit/4068224bf3cf191eb8f61ce76c16153769e0e795 by Jenkins.

# Links

- Slack [#brewery-team-alerting](https://instana.slack.com/archives/C02FF10TDTP/p1656572149857339?thread_ts=1656530857.174319&cid=C02FF10TDTP)
- Slack [#tech-dev](https://instana.slack.com/archives/G59JUG0NB/p1656570291206019)