### PR TITLE
[R235] Remove tagFilters from deprecated section for Website/Application SA

### DIFF
--- a/spec/descriptions/createWebsiteAlertConfig.md
+++ b/spec/descriptions/createWebsiteAlertConfig.md
@@ -23,5 +23,3 @@ This API endpoint creates the Website Alert Configuration.
 - **timeThreshold:** Indicates the type of violation of the defined threshold.
 
 - **alertChannelIds:** List of IDs of alert channels defined in Instana.
-
-## Deprecated Parameters

--- a/spec/descriptions/createWebsiteAlertConfig.md
+++ b/spec/descriptions/createWebsiteAlertConfig.md
@@ -25,5 +25,3 @@ This API endpoint creates the Website Alert Configuration.
 - **alertChannelIds:** List of IDs of alert channels defined in Instana.
 
 ## Deprecated Parameters
-
-**tagFilters:** The list of tag filters. It is replaced by **tagFilterExpression**.

--- a/spec/descriptions/tagApplicationAlertConfiguration.md
+++ b/spec/descriptions/tagApplicationAlertConfiguration.md
@@ -90,6 +90,4 @@ The API endpoints of this group can be used to manage Application alert configur
 
 ## Deprecated Parameters
 
-- **tagFilters:** The list of tag filters. It is replaced by **tagFilterExpression**.
-
 - **applicationId:** Unique ID of the Application Perspective. It is replaced by **applications**.

--- a/spec/descriptions/updateWebsiteAlertConfig.md
+++ b/spec/descriptions/updateWebsiteAlertConfig.md
@@ -25,5 +25,3 @@ This API endpoint updates the Website Alert Configuration.
 - **timeThreshold:** Indicates the type of violation of the defined threshold.
 
 - **alertChannelIds:** List of IDs of alert channels defined in Instana.
-
-## Deprecated Parameters

--- a/spec/descriptions/updateWebsiteAlertConfig.md
+++ b/spec/descriptions/updateWebsiteAlertConfig.md
@@ -27,5 +27,3 @@ This API endpoint updates the Website Alert Configuration.
 - **alertChannelIds:** List of IDs of alert channels defined in Instana.
 
 ## Deprecated Parameters
-
-**tagFilters:** The list of tag filters. It is replaced by **tagFilterExpression**.


### PR DESCRIPTION
# Why?

Field `tagFilters` in SmartAlerts was marked as deprecated more than 1 year ago. It need to be removed in BW-compatible way.

# What?

The `tagFilters` field is removed from AP/Website SmartAlerts.