### PR TITLE
Indicate that the playbackMode is optional and its default value is Simultenous

### DIFF
--- a/spec/descriptions/tagSyntheticSettings.md
+++ b/spec/descriptions/tagSyntheticSettings.md
@@ -74,6 +74,6 @@ These endpoints are only available for invited customers for the Synthetic Monit
   PoPs. Possible values are Simultaneous or Staggered. Simultaneous
   Synthetic tests run at all locations simultaneously. Staggered
   Synthetic tests run from a different location at each interval.
-  Default is Staggered. This property is optional, and its default value is Simultaneous.
+  This property is optional, and its default value is Simultaneous.
 - **testFrequency** How often the playback for a Synthetic test is scheduled. The unit of the testFrequency parameter is minute.
   The default is every 15 minutes. The range is from 1 minute to 120 minutes.

--- a/spec/descriptions/tagSyntheticSettings.md
+++ b/spec/descriptions/tagSyntheticSettings.md
@@ -74,6 +74,6 @@ These endpoints are only available for invited customers for the Synthetic Monit
   PoPs. Possible values are Simultaneous or Staggered. Simultaneous
   Synthetic tests run at all locations simultaneously. Staggered
   Synthetic tests run from a different location at each interval.
-  Default is Staggered.
+  Default is Staggered. This property is optional, and its default value is Simultaneous.
 - **testFrequency** How often the playback for a Synthetic test is scheduled. The unit of the testFrequency parameter is minute.
   The default is every 15 minutes. The range is from 1 minute to 120 minutes.


### PR DESCRIPTION
Per https://instana.kanbanize.com/ctrl_board/132/cards/110500/details/: In the process of redesigning the "create a test" flow and designing the alerting for synthetic monitoring, design, PM and dev eng came to the conclusion that no customers have asked us for "staggered" support.  Only one customer in APM ever asked for "staggered" type of playback. Cross and Rui have suggested that we should change things to make specification of the Playback mode optional, and default to Simultaneous if it's not specified.  This card is meant to handle the API changes only.  There will be separate cards for the new "create a test" flow.

Update the description of playbackMode accordingly: 

<img width="587" alt="Screen Shot 2022-12-09 at 4 31 26 PM" src="https://user-images.githubusercontent.com/73367095/206818916-cf1bea89-b673-4f4f-ac69-bdfdc3c2b9c3.png">
