### PR TITLE
Add API Script Guide documentation link in the HTTPScriptConfiguration section

### DIFF
--- a/spec/descriptions/tagSyntheticSettings.md
+++ b/spec/descriptions/tagSyntheticSettings.md
@@ -64,6 +64,7 @@ These endpoints are only available for invited customers for the Synthetic Monit
               - **scriptFile** The name of the file to run
               - **bundle** All required js files bundled up into a single zip file with base64 encoded
           - **syntheticType** Its value is HTTPScript. It is required.
+          - The API Script Guide can be found at: https://www.ibm.com/docs/en/instana-observability/current?topic=preview-api-script
 - **createdAt** The test created time, following RFC3339 standard.
 - **createdBy** The user identifier who created the test resource.
 - **customProperties** An object with name/value pairs to provide additional information of the Synthetic test.


### PR DESCRIPTION
In Synthetic-Test-Properties => Configuration => HTTPScriptConfiguration section, added: 
- The API Script Guide can be found at: https://www.ibm.com/docs/en/instana-observability/current?topic=preview-api-script

Kanbanize Card: https://instana.kanbanize.com/ctrl_board/132/cards/110132/details/