### PR TITLE
Artifactory migration to delivery.instana.io

### DIFF
--- a/ci/maven-settings.xml
+++ b/ci/maven-settings.xml
@@ -1,0 +1,36 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>int-maven-backend-local</id>
+      <username>${ARTIFACTORY_USERNAME}</username>
+      <password>${ARTIFACTORY_PASSWORD}</password>
+    </server>
+  </servers>
+
+  <mirrors>
+    <mirror>
+      <id>int-maven-backend-local</id>
+      <url>https://delivery.instana.io/artifactory/int-maven-backend-local/</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+
+  <profiles>
+    <profile>
+      <id>artifactory</id>
+      <repositories>
+        <repository>
+          <id>int-maven-backend-local</id>
+          <url>https://delivery.instana.io/artifactory/int-maven-backend-local/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>artifactory</activeProfile>
+  </activeProfiles>
+</settings>

--- a/ci/publish.bash
+++ b/ci/publish.bash
@@ -26,7 +26,8 @@ BRANCH_NAME=${BRANCH_NAME:='master'}
 SCRIPT_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
 
 echo "Downloading new OpenAPI spec..."
-mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get \
+mvn -s ci/maven-settings.xml \
+    org.apache.maven.plugins:maven-dependency-plugin:2.8:get \
     -Dartifact=com.instana:openapi:${VERSION}:yaml \
     -Ddest=${SCRIPT_ROOT_DIR}/spec/openapi.yaml
 


### PR DESCRIPTION
# What

- add `maven-settings.xml` file to use `https://delivery.instana.io/artifactory/int-maven-backend-local/` as a repository.
- use it when fetching openapi model 