### PR TITLE
infra analyze requires beeinstana

### DIFF
--- a/spec/descriptions/tagInfrastructureAnalyze.md
+++ b/spec/descriptions/tagInfrastructureAnalyze.md
@@ -4,6 +4,10 @@ It is also possible to [search and filter entities](#operation/getEntities) and 
 
 ## Important notes
 
+### Prerequisites
+
+For self-hosted installations, Beeinstana is required for this endpoint group.
+
 ### Timeframe
 
 **timeFrame** As in the Instana dashboards, you can specify the timeframe for metrics retrieval.

--- a/spec/descriptions/tagInfrastructureAnalyze.md
+++ b/spec/descriptions/tagInfrastructureAnalyze.md
@@ -6,7 +6,8 @@ It is also possible to [search and filter entities](#operation/getEntities) and 
 
 ### Prerequisites
 
-For self-hosted installations, Beeinstana is required for this endpoint group.
+For self-hosted installations, BeeInstana is required for this endpoint group.
+See this [documentation for enabling BeeInstana](https://www.ibm.com/docs/en/instana-observability/current?topic=premises-installing-instana-backend-docker#beeinstana-metric-pipeline-beta).
 
 ### Timeframe
 


### PR DESCRIPTION
Infrastructure Analyze relies heavily on Beeinstana and all endpoints require it to be running. Although this is the case for SaaS, self-hosted installations can be configured to run without it. In such cases, Infra Analyze endpoints return `200 OK` status with an empty body. Possibly another code should be used.

➡️ First and foremost, documentation should be updated accordingly.