### PR TITLE
fix link to jenkins task

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ OpenAPI specification for the Instana public API hosted on [Github Pages](https:
 
 ## Publishing Changes
 
-This is done via [Jenkins](https://dev-jenkins.instana.io/job/openapi-deploy-pipeline/) by specifying the `VERSION` of the Instana backend to use to obtain the new OpenAPI spec from.
+This is done via [Jenkins](https://dev-jenkins.instana.club/job/openapi-deploy-pipeline/) by specifying the `VERSION` of the Instana backend to use to obtain the new OpenAPI spec from.


### PR DESCRIPTION
Jenkins link refers to previous Jenkins installation. We should use the `.club` URL instead.