### PR TITLE
remove jenkins link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ OpenAPI specification for the Instana public API hosted on [Github Pages](https:
 
 ## Publishing Changes
 
-This is done via [Jenkins](https://dev-jenkins.instana.club/job/openapi-deploy-pipeline/) by specifying the `VERSION` of the Instana backend to use to obtain the new OpenAPI spec from.
+This is done via Jenkins using the `openapi-deploy-pipeline` job.


### PR DESCRIPTION
We should not refer to internal domains in this public repository.