### PR TITLE
Updating synthetic test PATCH doc

### DIFF
--- a/spec/descriptions/patchSyntheticTest.md
+++ b/spec/descriptions/patchSyntheticTest.md
@@ -1,9 +1,11 @@
 This API endpoint updates selected attributes of a Synthetic Test.
 
 - All attributes listed as in the schema, including the required ones, are optional for this call.
+- Synthetic Test configuration properties set to null will be removed from the configuration.
+- For major updates to the Synthetics Test or to remove main attributes, see "Update a Synthetic test"
 
 ## Sample script and payload: 
-- A sample script to patch a simple Ping API test to disable it.
+- A sample script to patch a simple HTTP Script Test to enable it and to switch from multi-scripts to single script.
 
 ```
 curl -k -v -X PATCH \
@@ -11,6 +13,10 @@ https://<Host>/api/synthetics/settings/tests/Ilfs9bW97KkTxuyGtxBF \
 -H 'authorization: apiToken <Token>' \
 -H 'content-type: application/json' \
 -d '{
-    "active":false
+    "active" : enable,
+    "configuration" : { 
+      "scripts" : null,
+      "script" : "//script goes here"
+    }
   }'
 ```


### PR DESCRIPTION
Documenting support for configuration attributes removal using `null` properties on the PATCH payloads.