### PR TITLE
Extend getEvents with deprecated fields

### DIFF
--- a/spec/descriptions/getEvents.md
+++ b/spec/descriptions/getEvents.md
@@ -8,6 +8,9 @@ This endpoint retrieves all available events for the requested timeframe.
 - **excludeTriggeredBefore:** Whether to exclude events that have been triggered before the requested timeframe in order to enable searching for events that have started within the given timeframe, excluding events that are previously active already. This is useful for 3rd party integrations that fetch events from Instana with a scheduled batch job in a fixed interval using tumbling windows, when you only care about new events.
 This option is more restrictive than `filterEventUpdates` and does not inform about event state updates that got `CLOSED` in the timeframe of the query if not also the start time of the event is within that query timeframe.
 - **filterEventUpdates:** Filters results to event updates only. This means that an event is only included when its event state changed in the given query timeframe. This is useful for 3rd party integrations that fetch events from Instana with a scheduled batch job in a fixed interval using a tumbling windows, when you care about event state updates.
+
+### Deprecated Parameters
+
 - **includeAgentMonitoringIssues:** Optional flag to indicate whether to include Agent Monitoring Issues. The default is `false`.
 - **includeKubernetesInfoEvents:** Optional flag to indicate whether to include Kubernetes Info Events. The default is `false`.
 


### PR DESCRIPTION
# Why/What

As a result of the findings in https://instana.kanbanize.com/ctrl_board/37/cards/135270/details/ , we noticed that the params such as `includeAgentMonitoringIssues` and `includeKubernetesInfoEvents` are not being used in any of the prod regions.

We added 2 separate endpoints as part of https://github.ibm.com/instana/backend/pull/19362 and would like to mark the above fields as deprecated. 

# References

- [Story / Card](https://instana.kanbanize.com/ctrl_board/37/cards/136334/details/)