### PR TITLE
Add a note that DNSAction is not supported

### DIFF
--- a/spec/descriptions/createSyntheticTest.md
+++ b/spec/descriptions/createSyntheticTest.md
@@ -1,6 +1,6 @@
 This API endpoint creates a Synthetic Test.
 
-**Note:** The **DNSAction** type is not supported.
+**Note:** The **DNSAction** Synthetic type is not supported.
 
 ## Sample script and payload: 
 - A sample script to create an API Simple test

--- a/spec/descriptions/createSyntheticTest.md
+++ b/spec/descriptions/createSyntheticTest.md
@@ -1,5 +1,7 @@
 This API endpoint creates a Synthetic Test.
 
+**Note:** The **DNSAction** type is not supported.
+
 ## Sample script and payload: 
 - A sample script to create an API Simple test
 


### PR DESCRIPTION
In spec/descriptions/createSyntheticTest.md, explicitly state that the DNSAction type is not supported. 