### PR TITLE
Document result inconsistencies for getServicesMap

### DIFF
--- a/spec/descriptions/getServicesMap.md
+++ b/spec/descriptions/getServicesMap.md
@@ -1,0 +1,8 @@
+This endpoint retrieves services and connections (call paths) between them for calls in the scope given by the parameters.
+
+## Errata:
+
+The following fields are unsupported but documented in the schema for the result `services`:
+- The `applications` field is always missing, even though it is declared as required in the result schema.
+- The `maxSeverity` and `numberOfOpenIssues` fields are always missing.
+- The `snapshotIds` field is always empty.


### PR DESCRIPTION
Customer reported unsupported result fields in the spec.
Can't fix the OpenAPI spec without affecting generated clients in a possibly breaking way, so just documenting the deficiencies.