### PR TITLE
Update - Get Traces Supported OrderBy

### DIFF
--- a/spec/descriptions/getTraces.md
+++ b/spec/descriptions/getTraces.md
@@ -1,11 +1,3 @@
 This endpoint retrieves the metrics for traces.
 
-**Manditory Paramters:**
-
-**Optional Paramters:**
-
-**Defaults:**
-
-**Limits:**
-
-**Tips:**
+**order.by:** Supported values include: `traceId`, `traceLabel`, `serviceLabel`, `duration` and `timestamp`.


### PR DESCRIPTION
Previously,` Get all traces` (//api/application-monitoring/analyze/traces) were automatically sorted by timestamp (t) in descending order. Now, users can also sort by `traceId`, `traceLabel`, `duration`, `serviceLabel`, or `timestamp`