### PR TITLE
Convert to Declarative Pipeline for issue: https://jsw.ibm.com/browse/INSTA-14651

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,42 +1,59 @@
-#!groovy
+pipeline {
+    agent any
 
-// define global vars for use in later stages
-def gitCommitId = null
+    environment {
+        // Set any environment variables if required
+    }
 
-stage('Checkout') {
-  node {
-    deleteDir()
+    stages {
+        stage('Checkout') {
+            steps {
+                script {
+                    deleteDir()
+                    checkout scm
 
-    checkout scm
-
-    gitCommitId = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
-
-    currentBuild.displayName = "#${env.BUILD_NUMBER}:${env.VERSION}"
-  }
-}
-
-stage ('Generate and publish OpenAPI specs') {
-  node {
-    timeout(time: 10, unit: 'MINUTES') {
-      if (env.BRANCH_NAME == 'master') {
-        withCredentials([usernamePassword(credentialsId: 'delivery-instana-io-internal-project-artifact-read-writer-creds', usernameVariable: 'DELIVERY_INSTANA_USR', passwordVariable: 'DELIVERY_INSTANA_PWD')]) {
-          sh "./ci/publish.bash ${env.VERSION} ${env.BUILD_URL}"
+                    gitCommitId = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+                    currentBuild.displayName = "#${env.BUILD_NUMBER}:${env.VERSION}"
+                }
+            }
         }
-      }
-    }
-  }
-}
 
-stage ('Trigger API end-to-end tests') {
-  timeout(time: 30, unit: 'MINUTES') {
-    if (env.BRANCH_NAME == 'master') {
-      def versionParts = env.VERSION.tokenize('.')
-      def releaseNumber = versionParts[1]
+        stage('Generate and publish OpenAPI specs') {
+            when {
+                expression { env.BRANCH_NAME == 'master' }
+            }
+            steps {
+                timeout(time: 10, unit: 'MINUTES') {
+                    script {
+                        withCredentials([usernamePassword(
+                            credentialsId: 'delivery-instana-io-internal-project-artifact-read-writer-creds',
+                            usernameVariable: 'DELIVERY_INSTANA_USR',
+                            passwordVariable: 'DELIVERY_INSTANA_PWD'
+                        )]) {
+                            sh "./ci/publish.bash ${env.VERSION} ${env.BUILD_URL}"
+                        }
+                    }
+                }
+            }
+        }
 
-      build job: '/tests/rest-api-e2e-tests', parameters: [
-          string(name: 'BRANCH_NAME', value: "release-${releaseNumber}"),
-          string(name: 'ENVIRONMENT', value: 'preview-instana')
-      ]
+        stage('Trigger API end-to-end tests') {
+            when {
+                expression { env.BRANCH_NAME == 'master' }
+            }
+            steps {
+                timeout(time: 30, unit: 'MINUTES') {
+                    script {
+                        def versionParts = env.VERSION.tokenize('.')
+                        def releaseNumber = versionParts[1]
+
+                        build job: '/tests/rest-api-e2e-tests', parameters: [
+                            string(name: 'BRANCH_NAME', value: "release-${releaseNumber}"),
+                            string(name: 'ENVIRONMENT', value: 'preview-instana')
+                        ]
+                    }
+                }
+            }
+        }
     }
-  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,8 @@ pipeline {
     agent any
 
     environment {
-        // Set any environment variables if required
+        // Define global variables here if needed
+        GIT_COMMIT_ID = ''
     }
 
     stages {
@@ -12,7 +13,7 @@ pipeline {
                     deleteDir()
                     checkout scm
 
-                    gitCommitId = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+                    env.GIT_COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
                     currentBuild.displayName = "#${env.BUILD_NUMBER}:${env.VERSION}"
                 }
             }
@@ -20,40 +21,44 @@ pipeline {
 
         stage('Generate and publish OpenAPI specs') {
             when {
-                expression { env.BRANCH_NAME == 'master' }
+                expression { return env.BRANCH_NAME == 'master' }
+            }
+            options {
+                timeout(time: 10, unit: 'MINUTES')
             }
             steps {
-                timeout(time: 10, unit: 'MINUTES') {
-                    script {
-                        withCredentials([usernamePassword(
-                            credentialsId: 'delivery-instana-io-internal-project-artifact-read-writer-creds',
-                            usernameVariable: 'DELIVERY_INSTANA_USR',
-                            passwordVariable: 'DELIVERY_INSTANA_PWD'
-                        )]) {
-                            sh "./ci/publish.bash ${env.VERSION} ${env.BUILD_URL}"
-                        }
-                    }
+                withCredentials([usernamePassword(credentialsId: 'delivery-instana-io-internal-project-artifact-read-writer-creds', 
+                                                 usernameVariable: 'DELIVERY_INSTANA_USR', 
+                                                 passwordVariable: 'DELIVERY_INSTANA_PWD')]) {
+                    sh "./ci/publish.bash ${env.VERSION} ${env.BUILD_URL}"
                 }
             }
         }
 
         stage('Trigger API end-to-end tests') {
             when {
-                expression { env.BRANCH_NAME == 'master' }
+                expression { return env.BRANCH_NAME == 'master' }
+            }
+            options {
+                timeout(time: 30, unit: 'MINUTES')
             }
             steps {
-                timeout(time: 30, unit: 'MINUTES') {
-                    script {
-                        def versionParts = env.VERSION.tokenize('.')
-                        def releaseNumber = versionParts[1]
+                script {
+                    def versionParts = env.VERSION.tokenize('.')
+                    def releaseNumber = versionParts[1]
 
-                        build job: '/tests/rest-api-e2e-tests', parameters: [
-                            string(name: 'BRANCH_NAME', value: "release-${releaseNumber}"),
-                            string(name: 'ENVIRONMENT', value: 'preview-instana')
-                        ]
-                    }
+                    build job: '/tests/rest-api-e2e-tests', parameters: [
+                        string(name: 'BRANCH_NAME', value: "release-${releaseNumber}"),
+                        string(name: 'ENVIRONMENT', value: 'preview-instana')
+                    ]
                 }
             }
+        }
+    }
+
+    post {
+        always {
+            // Actions to perform after the pipeline completes, such as cleanup or notifications
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,10 +55,4 @@ pipeline {
             }
         }
     }
-
-    post {
-        always {
-            // Actions to perform after the pipeline completes, such as cleanup or notifications
-        }
-    }
 }


### PR DESCRIPTION
#Why
In backend-jenkins, the [openapi-deploy-pipeline](https://backend-jenkins.instana.club/job/openapi-deploy-pipeline/) is running into problems where the different stages of the pipeline are running on different workers, which is causing the builds to fail. Hence, changing this to a declarative pipeline would resolve that issue by making it run on the same worker while also keeping all the initial functionalities intact.

Current Failure: https://backend-jenkins.instana.club/job/openapi-deploy-pipeline/5/console

#What
Converted the pipeline to a declarative pipeline

#Issue
JIRA: [INSTA-14651](https://jsw.ibm.com/browse/INSTA-14651)
