### PR TITLE
INSTA-15540: Remove Private Preview phrase from Synthetic monitoring API document

### DIFF
--- a/spec/descriptions/tagSyntheticSettings.md
+++ b/spec/descriptions/tagSyntheticSettings.md
@@ -96,7 +96,7 @@ The API endpoints of this group can be used to manage Synthetic Locations, Synth
 - **createdBy** The user identifier who created the test resource.
 - **customProperties** An object with name/value pairs to provide additional information of the Synthetic test.
 - **locations** It is an array of the PoP location IDs where the Synthetic tests are located.
-- **applications** (Private Preview) It is an array of the unique identifiers of the Application Perspectives associated to this test.
+- **applications** It is an array of the unique identifiers of the Application Perspectives associated to this test.
 - **modifiedAt** The test last updated time, following RFC3339 standard.
 - **modifiedBy** The user identifier who updated the test resource.
 - **playbackMode** Defines how the Synthetic test should be executed across multiple
@@ -114,7 +114,7 @@ All Script Tests can use credentials in their body and API Simple Tests can use 
 
 It is required that the credentials used in the test be created before the test is created or modified.
 
-(Private Preview) Credentials can be associated to multiple Application Perspectives, Websites, and Mobile Apps.
+Credentials can be associated to multiple Application Perspectives, Websites, and Mobile Apps.
 
 Tests using credentials are validated during test creation and update whether you use the API or UI, as follows:
 
@@ -124,5 +124,5 @@ Tests using credentials are validated during test creation and update whether yo
 2. The credentials or secrets used in the test must exist.  
   Requests to create or update a test referencing credentials that do not exist will fail with return code `Bad Request`.
 
-3. (Private Preview) Credentials associated to Application Perspectives, Websites, and Mobile Apps can only be used by tests that are associated to at least one common Application Perspective, Websites, and MobileApps.
+3. Credentials associated to Application Perspectives, Websites, and Mobile Apps can only be used by tests that are associated to at least one common Application Perspective, Websites, and MobileApps.
    Requests to create or update a test referencing credentials without matching Application Perspectives, Websites, or Mobile Apps will fail with return code `Bad Request`.


### PR DESCRIPTION
Synthetic monitoring RBAC improvement will go GA in R284, so remove Private Preview from the corresponding API document. 

Story: https://jsw.ibm.com/browse/INSTA-15540