### PR TITLE
INSTA-18327: Removing duplicated descriptions

### DIFF
--- a/spec/descriptions/tagSyntheticResults.md
+++ b/spec/descriptions/tagSyntheticResults.md
@@ -431,15 +431,3 @@ A payload only needs either tagFilters or tagFilterExpression as a filter, not b
      }
 }
 ```
-
-## Get Synthetic test playback result detail data
-
-### Query Parameters
-**type** The type of the detailed data. Its value is one of these types: SUBTRANSACTIONS, LOGS, and HAR.
-
-**name** The name of the file to be retrieved, if more than one file available for the same type. Used when the type equals to LOGS or IMAGES
-
-## Download a Synthetic test playback result detail data file
-
-### Query Parameter
-**type** The type of a single compressed file. Its value is one of these types: SUBTRANSACTIONS, LOGS, IMAGES, VIDEOS, and HAR.


### PR DESCRIPTION
The description of the Synthetic result metadata and detailed data APIs was moved to the actual API implementation on the backend repo.

- Story: [INSTA-18327](https://jsw.ibm.com/browse/INSTA-18327)
