### PR TITLE
Add API Endpoint description for `Add application configuration` endpoint

### DIFF
--- a/spec/descriptions/addApplicationConfig.md
+++ b/spec/descriptions/addApplicationConfig.md
@@ -1,4 +1,9 @@
-Create a new Application Perspective.
+Use this API endpoint if one wants to create a new Application Perspective. This endpoint requires `canConfigureApplications` permission. 
+
+One can use `Create or update an API token` endpoint to update the permission by setting `canConfigureApplications` to `true`.
+If one wants to enable the permission from Instana UI, go to Settings -> Security & Access -> Access Control -> API Token.
+There one can update the existing token or create a new token and set `Configuration of applications` to `true`.
+
 
 ## Deprecated Parameters
 **matchSpecification:** A binary tree sturcture of match expression connected with binary operator AND or OR. It is replaced by **tagFilterExpression** which is also used in Application Analyze API endpoints.


### PR DESCRIPTION
# Why
Goal is to make the API document more user friendly. Presently There is a scope of improvement in our Instana API Docs. For now, we intend to fix non-breaking changes in the documentation, eg: improve sample examples, add description to the fields, add more description somewhere in the API doc, etc. Focusing on All Application Configurations.

# What
- Added API Endpoint descriptions.
- Schema descriptions has already been added in this private repo [PR](https://github.ibm.com/instana/backend/pull/26207).

# Before
<img width="845" alt="image" src="https://github.com/user-attachments/assets/d0817646-7f2d-40c6-92ea-8996d36ed440">

# After
<img width="912" alt="image" src="https://github.com/user-attachments/assets/d9ae9c3d-176c-4004-acc6-f2a8f5a1e686">
