### PR TITLE
API Endpoint descriptions for Manual Service Configuration APIs

### DIFF
--- a/spec/descriptions/addManualServiceConfigs.md
+++ b/spec/descriptions/addManualServiceConfigs.md
@@ -1,21 +1,22 @@
-Add a manual service configuration.
+Use this API endpoint if one wants to add a manual service configuration. This endpoint requires `CanConfigureServiceMapping` permission. 
+
+One can use `Create or update an API token` endpoint to update the permission by setting `canConfigureServiceMapping` to `true`.
+If one wants to enable the permission from Instana UI, go to Settings -> Security & Access -> Access Control -> API Token.
+There one can update the existing token or create a new token and set `Customize service rules and endpoint mapping` to `true`.
 
 **This is an experimental endpoint to workaround service mapping issues.**
 
-### Mandatory Parameters:
+### Use cases
 
-**tagFilterExpression** A tag filter expression to match calls on which the manual service configuration will be applied. Only call tags are allowed in the expression.
+The manual service configuration APIs enables mapping calls to services using tag filter expressions based on call tags.
 
-### Optional Parameters:
-**unmonitoredServiceName** Specify a service name if you want to map calls to an unmonitored service.
+There are two use cases on the usage of these APIs:
 
-**existingServiceId** Specify a service id if you want to map calls to an existing service.
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.
 
-**description** A description of the configuration.
+### Important Note
 
-**enabled** Enable or disable the configuration.
+1. Use `tagfilterExpression` to match calls on which the manual service configuration will be applied. **Only call tags are allowed** in the tag filter expression.
 
-Note: Either unmonitoredServiceName or existingServiceId should be specified in a configuration.
-
-### Defaults
-**enabled** `true`
+2.  Either `unmonitoredServiceName` or `existingServiceId` should be specified in a configuration.

--- a/spec/descriptions/addManualServiceConfigs.md
+++ b/spec/descriptions/addManualServiceConfigs.md
@@ -12,7 +12,7 @@ The manual service configuration APIs enables mapping calls to services using ta
 
 There are two use cases on the usage of these APIs:
 
-1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.ibm.com`, `www.ibm.fr`) into a single service named `IBM` using the `call.http.host tag`.
 2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.
 
 ### Important Note

--- a/spec/descriptions/deleteManualServiceConfigs.md
+++ b/spec/descriptions/deleteManualServiceConfigs.md
@@ -1,3 +1,16 @@
-Delete a manual service configuration.
+Use this API endpoint if one wants to delete a manual service configuration. This endpoint requires `CanConfigureServiceMapping` permission. 
+
+One can use `Create or update an API token` endpoint to update the permission by setting `canConfigureServiceMapping` to `true`.
+If one wants to enable the permission from Instana UI, go to Settings -> Security & Access -> Access Control -> API Token.
+There one can update the existing token or create a new token and set `Customize service rules and endpoint mapping` to `true`.
 
 **This is an experimental endpoint to workaround service mapping issues.**
+
+### Use cases
+
+The manual service configuration APIs enables mapping calls to services using tag filter expressions based on call tags.
+
+There are two use cases on the usage of these APIs:
+
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.

--- a/spec/descriptions/deleteManualServiceConfigs.md
+++ b/spec/descriptions/deleteManualServiceConfigs.md
@@ -12,5 +12,5 @@ The manual service configuration APIs enables mapping calls to services using ta
 
 There are two use cases on the usage of these APIs:
 
-1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.ibm.com`, `www.ibm.fr`) into a single service named `IBM` using the `call.http.host tag`.
 2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.

--- a/spec/descriptions/getAllManualServiceConfigs.md
+++ b/spec/descriptions/getAllManualServiceConfigs.md
@@ -1,3 +1,16 @@
-Get all manual service configurations.
+Use this API Endpoint if one wants to retrieve a list of all manual service configurations. This endpoint requires `CanConfigureServiceMapping` permission. 
+
+One can use `Create or update an API token` endpoint to update the permission by setting `canConfigureServiceMapping` to `true`.
+If one wants to enable the permission from Instana UI, go to Settings -> Security & Access -> Access Control -> API Token.
+There one can update the existing token or create a new token and set `Customize service rules and endpoint mapping` to `true`.
 
 **This is an experimental endpoint to workaround service mapping issues.**
+
+### Use cases
+
+The manual service configuration APIs enables mapping calls to services using tag filter expressions based on call tags.
+
+There are two use cases on the usage of these APIs:
+
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.

--- a/spec/descriptions/getAllManualServiceConfigs.md
+++ b/spec/descriptions/getAllManualServiceConfigs.md
@@ -12,5 +12,5 @@ The manual service configuration APIs enables mapping calls to services using ta
 
 There are two use cases on the usage of these APIs:
 
-1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.ibm.com`, `www.ibm.fr`) into a single service named `IBM` using the `call.http.host tag`.
 2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.

--- a/spec/descriptions/replaceAllManualServiceConfigs.md
+++ b/spec/descriptions/replaceAllManualServiceConfigs.md
@@ -12,7 +12,7 @@ The manual service configuration APIs enables mapping calls to services using ta
 
 There are two use cases on the usage of these APIs:
 
-1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.ibm.com`, `www.ibm.fr`) into a single service named `IBM` using the `call.http.host tag`.
 2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.
 
 ### Important Note

--- a/spec/descriptions/replaceAllManualServiceConfigs.md
+++ b/spec/descriptions/replaceAllManualServiceConfigs.md
@@ -1,21 +1,22 @@
-Replace all manual service configurations.
+Use this API endpoint if one wants to update more than 1 manual service configurations. This endpoint requires `CanConfigureServiceMapping` permission. 
+
+One can use `Create or update an API token` endpoint to update the permission by setting `canConfigureServiceMapping` to `true`.
+If one wants to enable the permission from Instana UI, go to Settings -> Security & Access -> Access Control -> API Token.
+There one can update the existing token or create a new token and set `Customize service rules and endpoint mapping` to `true`.
 
 **This is an experimental endpoint to workaround service mapping issues.**
 
-### Mandatory Parameters:
+### Use cases
 
-**tagFilterExpression** A tag filter expression to match calls on which the manual service configuration will be applied. Only call tags are allowed in the expression.
+The manual service configuration APIs enables mapping calls to services using tag filter expressions based on call tags.
 
-### Optional Parameters:
-**unmonitoredServiceName** Specify a service name if you want to map calls to an unmonitored service.
+There are two use cases on the usage of these APIs:
 
-**existingServiceId** Specify a service id if you want to map calls to an existing service.
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.
 
-**description** A description of the configuration.
+### Important Note
 
-**enabled** Enable or disable the configuration.
+1. Use `tagfilterExpression` to match calls on which the manual service configuration will be applied. **Only call tags are allowed** in the tag filter expression.
 
-Note: Either unmonitoredServiceName or existingServiceId should be specified in a configuration.
-
-### Defaults
-**enabled** `true`
+2.  Either `unmonitoredServiceName` or `existingServiceId` should be specified in a configuration.

--- a/spec/descriptions/updateManualServiceConfigs.md
+++ b/spec/descriptions/updateManualServiceConfigs.md
@@ -8,7 +8,7 @@ The manual service configuration APIs enables mapping calls to services using ta
 
 There are two use cases on the usage of these APIs:
 
-1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.ibm.com`, `www.ibm.fr`) into a single service named `IBM` using the `call.http.host tag`.
 2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.
 
 ### Important Note

--- a/spec/descriptions/updateManualServiceConfigs.md
+++ b/spec/descriptions/updateManualServiceConfigs.md
@@ -1,21 +1,18 @@
-Update a manual service configuration.
+Use this API endpoint if one wants to update a manual service configuration.
 
 **This is an experimental endpoint to workaround service mapping issues.**
 
-### Mandatory Parameters:
+### Use cases
 
-**tagFilterExpression** A tag filter expression to match calls on which the manual service configuration will be applied. Only call tags are allowed in the expression.
+The manual service configuration APIs enables mapping calls to services using tag filter expressions based on call tags.
 
-### Optional Parameters:
-**unmonitoredServiceName** Specify a service name if you want to map calls to an unmonitored service.
+There are two use cases on the usage of these APIs:
 
-**existingServiceId** Specify a service id if you want to map calls to an existing service.
+1. Map to an Unmonitored Service with a Custom Name. For example, Map HTTP calls to different Google domains (`www.google.com`, `www.google.fr`) into a single service named `Google` using the `call.http.host tag`.
+2. Link Calls to an Existing Monitored Service. For example, Link database calls (`jdbc:mysql://10.128.0.1:3306`) to an existing service like `MySQL@3306` on demo-host by referencing its service ID.
 
-**description** A description of the configuration.
+### Important Note
 
-**enabled** Enable or disable the configuration.
+1. Use `tagfilterExpression` to match calls on which the manual service configuration will be applied. **Only call tags are allowed** in the tag filter expression.
 
-Note: Either unmonitoredServiceName or existingServiceId should be specified in a configuration.
-
-### Defaults
-**enabled** `true`
+2.  Either `unmonitoredServiceName` or `existingServiceId` should be specified in a configuration.


### PR DESCRIPTION
Adding endpoint descriptions for Manual Service Configuration APIs. Moved the schema descriptions on private GitHub PR https://github.ibm.com/instana/backend/pull/27133

# Before
<img width="429" alt="image" src="https://github.com/user-attachments/assets/d03bbde7-33ef-479c-b3c5-754088e3baab" />
<img width="825" alt="image" src="https://github.com/user-attachments/assets/58ed905e-7ea1-4155-86bc-bfb86c2cbe12" />
<img width="819" alt="image" src="https://github.com/user-attachments/assets/9c895169-b612-4491-837a-bb863c7725e6" />
<img width="593" alt="image" src="https://github.com/user-attachments/assets/3090b335-95c2-46a8-ba83-f79a7186492b" />
<img width="829" alt="image" src="https://github.com/user-attachments/assets/0b56eafa-e74f-488c-ba60-db1a99442138" />

# After
<img width="808" alt="image" src="https://github.com/user-attachments/assets/5c888f6e-b5ce-4a36-b6c4-a94389e4ef88" />
<img width="785" alt="image" src="https://github.com/user-attachments/assets/e089fbc4-038a-4c3d-9cd4-d1c7a5419d2d" />
<img width="815" alt="image" src="https://github.com/user-attachments/assets/53b97193-23d4-4c55-9ab6-70269d8cde51" />
<img width="811" alt="image" src="https://github.com/user-attachments/assets/77c26f51-e92d-45d2-97c2-52223ade6630" />
<img width="800" alt="image" src="https://github.com/user-attachments/assets/c043af77-2dfa-4bd5-9ab8-e92a11feea66" />
