### PR TITLE
corrected URI for `Get applications/services` endpoint

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -646,7 +646,7 @@ paths:
       summary: Get applications
       tags:
       - Application Resources
-  /api/application-monitoring/applications/services:
+  /api/application-monitoring/applications;id={application-id}/services:
     get:
       description: |
         Use this API endpoint if one wants to retrieve a list of Application/Services.


### PR DESCRIPTION
- changed URI from `/api/application-monitoring/applications/services` to `/api/application-monitoring/applications;id={application-id}/services/`