### PR TITLE
Documentation of Supported Aggregation on Application Metrics APIs, Get grouped Call and Trace metrics API

### DIFF
--- a/spec/descriptions/getCallGroup.md
+++ b/spec/descriptions/getCallGroup.md
@@ -2,3 +2,13 @@ This endpoint retrieves the metrics for calls.
 
 ## Deprecated Parameters
 **tagFilters:** The list of tag filters. It is replaced by **tagFilterExpression**, **includeInternal** and **includeSynthetic**.
+
+## Supported Aggregation on Get Grouped call metrics
+
+| Metric           | Description                                                                                | Allowed Aggregations |
+|------------------|--------------------------------------------------------------------------------------------|----------------------|
+| `calls`          | Number of received calls                                                                   | `PER_SECOND`, `SUM`  |
+| `erroneousCalls` | The number of erroneous calls                                                              |`PER_SECOND`, `SUM`   |
+| `latency`        | Latency of received calls in milliseconds                                                  | `P25`, `P50`, `P75`, `P90`, `P95`, `P98`, `P99`, `SUM`, `MEAN`, `MAX`, `MIN`        |
+| `errors`         | Error rate of received calls. A value between 0 and 1                                      | `MEAN`               |
+| `services`       | The number of Services                                                                     |`DISTINCT_COUNT`      |

--- a/spec/descriptions/getTraceGroups.md
+++ b/spec/descriptions/getTraceGroups.md
@@ -1,4 +1,11 @@
 The API endpoint retrieves metrics for traces that are grouped in the endpoint or service name.
 
 The supported `groupbyTag` are `trace.endpoint.name` and `trace.service.name`. 
-{: note}
+
+## Supported Aggregation on Get grouped trace metrics
+
+| Metric           | Description                                                                                | Allowed Aggregations |
+|------------------|--------------------------------------------------------------------------------------------|----------------------|
+| `erroneousCalls` | The number of erroneous calls                                                              |`PER_SECOND`, `SUM`   |
+| `latency`        | Latency of received calls in milliseconds                                                  | `P25`, `P50`, `P75`, `P90`, `P95`, `P98`, `P99`, `SUM`, `MEAN`, `MAX`, `MIN`        |
+| `errors`         | Error rate of received calls. A value between 0 and 1                                      | `MEAN`               |

--- a/spec/descriptions/tagApplicationAnalyze.md
+++ b/spec/descriptions/tagApplicationAnalyze.md
@@ -46,6 +46,9 @@ The timeFrame might be adjusted to fit the metric granularity so that there is n
    * Error Rate
    * Traces Sum
 2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalog endpoint](#operation/getApplicationCatalogMetrics) gives you the metrics with the available aggregations.
+
+**Note**: The above mentioned list of available metrics with its supported metrics can also be found in [Get grouped call metrics](#operation/getCallGroup) and [Get grouped trace metrics](#operation/getTraceGroups).
+
 3. *granularity* 
    * If it is not set you will get a an aggregated value for the selected timeframe
    * If the granularity is set you will get data points with the specified granularity **in seconds**

--- a/spec/descriptions/tagApplicationMetrics.md
+++ b/spec/descriptions/tagApplicationMetrics.md
@@ -65,7 +65,7 @@ To narrow down the result set you have four options to search for an application
 * no filters are applied in the default call
 
 
-### Supported Aggregation on Application Metrics
+## Supported Aggregation on Application Metrics
 
 | Metric           | Description                                                                                | Allowed Aggregations |
 |------------------|--------------------------------------------------------------------------------------------|----------------------|
@@ -81,4 +81,3 @@ To narrow down the result set you have four options to search for an application
 | `http.3xx`       | Counts the number of occurrences of HTTP status codes where 300 <= status code <= 399      |`PER_SECOND`, `SUM`   |
 | `http.4xx`       | Counts the number of occurrences of HTTP status codes where 400 <= status code <= 499      |`PER_SECOND`, `SUM`   |
 | `http.5xx`       | Counts the number of occurrences of HTTP status codes where 500 <= status code <= 599      |`PER_SECOND`, `SUM`   |
-

--- a/spec/descriptions/tagApplicationMetrics.md
+++ b/spec/descriptions/tagApplicationMetrics.md
@@ -2,8 +2,10 @@ The endpoints of this group retrieve the metrics for defined applications, disco
 ### Mandatory Parameters
 
 **metrics** A list of metric objects that define which metric should be returned, with the defined aggregation. Each metrics objects consists of minimum two items:
-1. *metric* select a particular metric to get a list of available metrics query the [catalog endpoint](#operation/getApplicationCatalogMetrics)
+1. *metric* select a particular metric to get a list of available metrics query the [catalog endpoint](#operation/getApplicationCatalogMetrics).
 2. *aggregation* depending on the selected metric different aggregations are available e.g. SUM, MEAN, P95. The aforementioned [catalog endpoint](#operation/getApplicationCatalogMetrics) gives you the metrics with the available aggregations.
+
+**Note**: The above mentioned list of available metrics with its supported metrics can also be found in the section **Supported Aggregation on Application metrics** below.
 
 ### Optional Parameters
 
@@ -61,3 +63,24 @@ To narrow down the result set you have four options to search for an application
 ```
 **nameFilter | applicationId | serviceId | endpointId**
 * no filters are applied in the default call
+
+
+### Supported Aggregation on Application Metrics
+
+| Metric           | Description                                                                                | Allowed Aggregations |
+|------------------|--------------------------------------------------------------------------------------------|----------------------|
+| `calls`          | Number of received calls                                                                   | `PER_SECOND`, `SUM`  |
+| `erroneousCalls` | The number of erroneous calls                                                              |`PER_SECOND`, `SUM`   |
+| `latency`        | Latency of received calls in milliseconds                                                  | `P25`, `P50`, `P75`, `P90`, `P95`, `P98`, `P99`, `SUM`, `MEAN`, `MAX`, `MIN`        |
+| `errors`         | Error rate of received calls. A value between 0 and 1                                      | `MEAN`               |
+| `traces`         | Number of traces                                                                           |`SUM`                 |
+| `applications`   | The number of Application Perspectives                                                     |`DISTINCT_COUNT`      |
+| `services`       | The number of Services                                                                     |`DISTINCT_COUNT`      |
+| `endpoints`      | The number of Endpoints                                                                    |`DISTINCT_COUNT`      |
+| `http.1xx`       | Counts the number of occurrences of HTTP status codes where 100 <= status code <= 199      |`PER_SECOND`, `SUM`   |
+| `http.2xx`       | Counts the number of occurrences of HTTP status codes where 200 <= status code <= 299      |`PER_SECOND`, `SUM`   |
+| `http.3xx`       | Counts the number of occurrences of HTTP status codes where 300 <= status code <= 399      |`PER_SECOND`, `SUM`   |
+| `http.4xx`       | Counts the number of occurrences of HTTP status codes where 400 <= status code <= 499      |`PER_SECOND`, `SUM`   |
+| `http.5xx`       | Counts the number of occurrences of HTTP status codes where 500 <= status code <= 599      |`PER_SECOND`, `SUM`   |
+| `call.metric`    | Custom-key metric explicitly set on the monitored call                                     |`SUM`, `MEAN`, `MAX`, `MIN`   |
+

--- a/spec/descriptions/tagApplicationMetrics.md
+++ b/spec/descriptions/tagApplicationMetrics.md
@@ -73,7 +73,6 @@ To narrow down the result set you have four options to search for an application
 | `erroneousCalls` | The number of erroneous calls                                                              |`PER_SECOND`, `SUM`   |
 | `latency`        | Latency of received calls in milliseconds                                                  | `P25`, `P50`, `P75`, `P90`, `P95`, `P98`, `P99`, `SUM`, `MEAN`, `MAX`, `MIN`        |
 | `errors`         | Error rate of received calls. A value between 0 and 1                                      | `MEAN`               |
-| `traces`         | Number of traces                                                                           |`SUM`                 |
 | `applications`   | The number of Application Perspectives                                                     |`DISTINCT_COUNT`      |
 | `services`       | The number of Services                                                                     |`DISTINCT_COUNT`      |
 | `endpoints`      | The number of Endpoints                                                                    |`DISTINCT_COUNT`      |
@@ -82,5 +81,4 @@ To narrow down the result set you have four options to search for an application
 | `http.3xx`       | Counts the number of occurrences of HTTP status codes where 300 <= status code <= 399      |`PER_SECOND`, `SUM`   |
 | `http.4xx`       | Counts the number of occurrences of HTTP status codes where 400 <= status code <= 499      |`PER_SECOND`, `SUM`   |
 | `http.5xx`       | Counts the number of occurrences of HTTP status codes where 500 <= status code <= 599      |`PER_SECOND`, `SUM`   |
-| `call.metric`    | Custom-key metric explicitly set on the monitored call                                     |`SUM`, `MEAN`, `MAX`, `MIN`   |
 


### PR DESCRIPTION
# Why
By adding a list of supported aggregation on available metrics, API users can know which aggregation to put on the metrics they want to fetch.

## TODO

- [x] validate the documentation by manually testing the APIs

## View on API Docs

<img width="859" alt="image" src="https://github.com/user-attachments/assets/0b95c735-2efc-4346-9f37-6e36ae2fcfe9" />

<img width="665" alt="image" src="https://github.com/user-attachments/assets/8016bcb4-80e0-4874-b472-ed1e31e74ada" />

<img width="760" alt="image" src="https://github.com/user-attachments/assets/ab39c38f-ae45-4130-b4d8-c891e1e6c054" />

<img width="771" alt="image" src="https://github.com/user-attachments/assets/842a7a08-0edc-4960-bc4c-e7ae729dab7d" />

