### PR TITLE
INSTA-54910 - Add redirect to new IBM Developer APIHub documentation URL

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,29 +1,47 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Instana API docs</title>
-    <!-- needed for adaptive design -->
+  <title>Instana OpenAPI - Redirecting...</title>
   <meta charset="utf-8"/>
-  <link rel="icon" type="image/png" href="favicon.png"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <link 
-  href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
-   rel="stylesheet"
-   />
-  <link href="banner.css" rel="stylesheet"/>
-
-  <!-- ReDoc doesn't change outer page styles -->
+  <link rel="icon" type="image/png" href="favicon.png"/>
+  
+  <!-- Redirect to new IBM Developer location -->
+  <script>
+    window.location.href = "https://developer.ibm.com/apis/catalog/instana--instana-rest-api/";
+  </script>
+  
   <style>
     body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       margin: 0;
-      padding: 0;
+      padding: 40px;
+      background-color: #f5f5f5;
+      text-align: center;
     }
-
-</style>
-  {{redocHead}}
+    .redirect-container {
+      max-width: 600px;
+      margin: 0 auto;
+      background: white;
+      padding: 40px;
+      border-radius: 8px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    }
+    .redirect-link {
+      color: #0066cc;
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .redirect-link:hover {
+      text-decoration: underline;
+    }
+  </style>
 </head>
 <body>
-  {{redocBody}}
-  <script src="banner.js"></script>
+  <div class="redirect-container">
+    <h1>Instana API Documentation</h1>
+    <p>Redirecting to the new Instana API documentation...</p>
+    <p>If you are not redirected automatically, <a href="https://developer.ibm.com/apis/catalog/instana--instana-rest-api/" class="redirect-link">click here</a>.</p>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Starting with release 307, the OpenAPI documentation will be deprecated as we transition to APIHub for hosting and managing Instana’s API documentation.

## Details

This PR introduces a redirect from the existing OpenAPI (Redocly) documentation to the corresponding APIHub page. This ensures that customers who have bookmarked the previous documentation URLs are seamlessly redirected to the official Instana API documentation on APIHub.

## References

Story: [INSTA-54910](https://jsw.ibm.com/browse/INSTA-54910)